### PR TITLE
missing js.scope

### DIFF
--- a/node/net.mli
+++ b/node/net.mli
@@ -1,5 +1,7 @@
 open Js
 
+[@@@js.scope Import.net]
+
 module BlockList : sig
   type t
 

--- a/node/net.mli
+++ b/node/net.mli
@@ -215,7 +215,7 @@ module Socket : sig
       [@@js.builder]
   end
 
-  val create : ?options:Options.t -> unit -> t [@@js.builder]
+  val create: ?options:Options.t -> unit -> t [@@js.new "Socket"]
 end
 
 module Server : sig


### PR DESCRIPTION
# Description 

There is a js.scope missing in the net.mli module to be able to use "globals". 